### PR TITLE
Fix system gallery read cache file

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -2474,6 +2474,7 @@ public class ImageLoader {
                         File imagePath = new File(telegramPath, "Telegram Images");
                         imagePath.mkdir();
                         if (imagePath.isDirectory() && canMoveFiles(cachePath, imagePath, FileLoader.MEDIA_DIR_IMAGE)) {
+                            AndroidUtilities.createEmptyFile(new File(imagePath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_IMAGE, imagePath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("image path = " + imagePath);
@@ -2487,6 +2488,7 @@ public class ImageLoader {
                         File videoPath = new File(telegramPath, "Telegram Video");
                         videoPath.mkdir();
                         if (videoPath.isDirectory() && canMoveFiles(cachePath, videoPath, FileLoader.MEDIA_DIR_VIDEO)) {
+                            AndroidUtilities.createEmptyFile(new File(videoPath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_VIDEO, videoPath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("video path = " + videoPath);
@@ -2557,6 +2559,7 @@ public class ImageLoader {
                         File imagePath = new File(publicMediaDir, "Telegram Images");
                         imagePath.mkdir();
                         if (imagePath.isDirectory() && canMoveFiles(cachePath, imagePath, FileLoader.MEDIA_DIR_IMAGE)) {
+                            AndroidUtilities.createEmptyFile(new File(imagePath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_IMAGE_PUBLIC, imagePath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("image path = " + imagePath);
@@ -2570,6 +2573,7 @@ public class ImageLoader {
                         File videoPath = new File(publicMediaDir, "Telegram Video");
                         videoPath.mkdir();
                         if (videoPath.isDirectory() && canMoveFiles(cachePath, videoPath, FileLoader.MEDIA_DIR_VIDEO)) {
+                            AndroidUtilities.createEmptyFile(new File(videoPath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_VIDEO_PUBLIC, videoPath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("video path = " + videoPath);


### PR DESCRIPTION
**English:**

In Android 10, if Momogram is given permission to read files, it will save cached files in the `/storage/emulated/0/Momogram` folder, but since it doesn't contain `.nomedia` files it will be scanned by the system gallery, resulting in a lot of garbage images and videos, so the creation of a .nomedia file was added Code

I'm very sorry because I'm not a native English speaker and may have some problems with the above description, but hopefully this PR will be accepted!

Finally thank you for maintaining this program for so long, I like it very much and use it all the time!

---

**中文：**

在安卓 10中，如果给予 Momogram 读取文件权限，那么它会把缓存文件保存在 `/storage/emulated/0/Momogram` 文件夹中，但由于没有包含 `.nomedia` 文件所以会被系统图库扫描，导致出现很多垃圾图片和视频，所以我添加了创建 `.nomedia` 文件的代码

非常抱歉，由于我的母语不是英语，可能在上面的描述中有些许问题，但希望这个PR可以被接纳

最后感谢您维护这个项目这么久，我非常喜欢它，并且一直在使用！