### PR TITLE
fix: update validation for Cloudflare token length checks

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/WhisperHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/WhisperHelper.java
@@ -167,13 +167,13 @@ public class WhisperHelper {
         if (button != null) {
             button.setOnClickListener(v -> {
                 var accountId = editTextAccountId.getText();
-                if (!TextUtils.isEmpty(accountId) && accountId.length() != 32) {
+                if (!TextUtils.isEmpty(accountId) && accountId.length() < 32) {
                     AndroidUtilities.shakeViewSpring(editTextAccountId, -6);
                     BotWebViewVibrationEffect.APP_ERROR.vibrate();
                     return;
                 }
                 var apiToken = editTextApiToken.getText();
-                if (!TextUtils.isEmpty(apiToken) && apiToken.length() != 40) {
+                if (!TextUtils.isEmpty(apiToken) && apiToken.length() < 40) {
                     AndroidUtilities.shakeViewSpring(editTextApiToken, -6);
                     BotWebViewVibrationEffect.APP_ERROR.vibrate();
                     return;


### PR DESCRIPTION
The new token is 53 characters long, while the old one was 40